### PR TITLE
Custom direct select

### DIFF
--- a/frontend/src/components/map/mapgl.tsx
+++ b/frontend/src/components/map/mapgl.tsx
@@ -10,15 +10,13 @@ import { TopoJSONToLineString, coordinatesAreEqual } from "./utils";
 import "./map.css";
 
 /**
- * TODO: Instead of snap to after finish drag, drag with...
- *        Might be possible with customizing a direct_select mode and modifying the drag events
  * Edge cases to fix:
- *  Handling vertix clicks where they aren't shared, new node
- *    There seems to be an event that happens sometimes that messes up the proccess
- *    Happens after I add a new node, then try to move a shared vertix.
- *    I think it has to do with the draw modes. It needs to get set back to multi-vert
  *
  *  Deleting node that has 2 shared verticies in same feature.
+ *
+ * TODO: The utility function to tell if point are the same vertex needs to become more sophisticated.
+ *        To ensure some reliability, it checks to the tenths decimal point on longitude and latitude.
+ *        This might be acceptable, unless someone wants to create a column with incredible granularity.
  */
 
 // Topojson
@@ -199,13 +197,6 @@ export function Map() {
       setZoom(map.getZoom().toFixed(2));
     });
 
-    map.on("draw.onDrag", function(state, e) {
-      console.log("DRAG");
-      console.log(e);
-    });
-
-    // maybe a custom editing that checks if there is another vertix at same point, and also select
-    // that one.
     // use the splice to replace coords
     // This needs to account for deleteing nodes. That falls under change_coordinates
     map.on("draw.update", function(e) {

--- a/frontend/src/components/map/utils.ts
+++ b/frontend/src/components/map/utils.ts
@@ -37,8 +37,8 @@ function TopoJSONToLineString(json) {
 function coordinatesAreEqual(props) {
   const { coord1, coord2 } = props;
   if (
-    coord1[0].toFixed(2) == coord2[0].toFixed(2) &&
-    coord1[1].toFixed(2) == coord2[1].toFixed(2)
+    coord1[0].toFixed(1) == coord2[0].toFixed(1) &&
+    coord1[1].toFixed(1) == coord2[1].toFixed(1)
   ) {
     return true;
   } else {


### PR DESCRIPTION
This create another custom draw mode, this time the `direct_select` so I can overwrite the `onDrag` to update the location of shared vertices as I drag instead of the snap-to after finishing drag.